### PR TITLE
Add support for custom prompt messages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,5 +27,5 @@ module.exports = function(grunt) {
   });
   grunt.loadTasks('tasks');
   grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.registerTask('default', ['jshint', 'step', 'jshint', 'step']);
+  grunt.registerTask('default', ['jshint', 'step:lint again?', 'jshint', 'step']);
 };

--- a/tasks/step.js
+++ b/tasks/step.js
@@ -9,9 +9,10 @@
 'use strict';
 
 module.exports = function(grunt) {
+  var format = require('util').format;
   var readline = require('readline');
 
-  grunt.registerTask('step', 'Add confirmation steps to your Grunt flow.', function() {
+  grunt.registerTask('step', 'Add confirmation steps to your Grunt flow.', function(text) {
     var options = this.options({
       option: 'ack',
     });
@@ -26,7 +27,8 @@ module.exports = function(grunt) {
       output: process.stdout
     });
 
-    rl.question('Do you want to continue? (Y/n) ', function(answer) {
+    text = format('%s (Y/n) ', text || 'Do you want to continue?');
+    rl.question(text, function(answer) {
       rl.close();
       if (answer.toLowerCase() === 'n') {
         done(false);


### PR DESCRIPTION
When deciding whether to continue or not, sometimes it's nice to have some additional context.

``` bash
# Do you want to continue? (Y/n)
grunt step --ack

# Push to master? (Y/n)
grunt step:'Push to master?' --ack
```
